### PR TITLE
:sparkles: defer gtag activation to the client

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,8 @@ The module includes Google `googletagmanager.com/gtag/js` into your project and 
 ```
 ## Usage
 
+This module inlcudes Google gtag in your NuxtJs project and enables every page tracking by default. You can use gtag inside of your components/functions/methods like follow:
+
 ```
   this.$gtag('event', 'your_event', { /* track something awesome */})
 ```

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ To begin tracking, typically after the visitor has given their consent, call `th
 
 ⚠️ No tracking will take place if `this.$enableGtagTracking()` is not called!
 
-The rest of the lib behavior remains intact. `this.$gtag(...)` can even be called before `this.$enableGtagTracking()` without errors, and without loss of events.
+The rest of the lib behavior remains intact. `this.$gtag(...)` can even be called before `this.$enableGtagTracking()` without errors or loss of events.
 
 The original documentation follows.
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ The module includes Google `googletagmanager.com/gtag/js` into your project and 
 }
 ```
 ## Usage
-If you want to enable Google Tag, you need to call the ``` enableGtagTracking ``` function in your app.
+If you want to enable Google Tag, you need to call the ` enableGtagTracking ` function in your app.
 
 Either by the mounted call of the main component of your app, either by a test condition where you want in your app.
 
@@ -73,8 +73,6 @@ methods: {
 },
 ```
 After this required step, this module inlcudes Google gtag in your NuxtJs project and enables every page tracking by default. You can use gtag inside of your components/functions/methods like follow:
-
-This module inlcudes Google gtag in your NuxtJs project and enables every page tracking by default. You can use gtag inside of your components/functions/methods like follow:
 
 ```
   this.$gtag('event', 'your_event', { /* track something awesome */})

--- a/README.md
+++ b/README.md
@@ -1,178 +1,100 @@
-
 # @nuxtjs/google-gtag
-
 [![npm (scoped with tag)](https://img.shields.io/npm/v/@nuxtjs/google-gtag/latest.svg?style=flat-square)](https://npmjs.com/package/@nuxtjs/google-gtag)
-
 [![npm](https://img.shields.io/npm/dt/@nuxtjs/google-gtag.svg?style=flat-square)](https://npmjs.com/package/@nuxtjs/google-gtag)
-
 [![CircleCI](https://img.shields.io/circleci/project/github/https://github.com/nuxt-community/google-gtag.svg?style=flat-square)](https://circleci.com/gh/https://github.com/nuxt-community/google-gtag)
-
 [![Codecov](https://img.shields.io/codecov/c/github/https://github.com/nuxt-community/google-gtag.svg?style=flat-square)](https://codecov.io/gh/https://github.com/nuxt-community/google-gtag)
-
 [![Dependencies](https://david-dm.org/https://github.com/nuxt-community/google-gtag/status.svg?style=flat-square)](https://david-dm.org/https://github.com/nuxt-community/google-gtag)
-
 [![js-standard-style](https://img.shields.io/badge/code_style-standard-brightgreen.svg?style=flat-square)](http://standardjs.com)
-
-  
 
 > Google official gtagjs for Nuxt.js
 
-  
-
 [📖 **Release Notes**](./CHANGELOG.md)
-
-  
 
 ## Features
 
-  
-
 The module includes Google `googletagmanager.com/gtag/js` into your project and enables it with config you pass in as options.
-
-  
 
 * Check the official reference [gtag](https://developers.google.com/analytics/devguides/collection/gtagjs/)
 
-  
-
 ## Setup
-
 - Add `@nuxtjs/google-gtag` dependency using yarn or npm to your project
-
 - Add `@nuxtjs/google-gtag` to `modules` section of `nuxt.config.js`
 
-  
-
 ```js
-
 {
+  modules: [
+    // Simple usage
+    '@nuxtjs/google-gtag',
 
-modules: [
-
-// Simple usage
-
-'@nuxtjs/google-gtag',
-
+    // With options
+    ['@nuxtjs/google-gtag', { /* module options */ }],    
+ ]
   
-
-// With options
-
-['@nuxtjs/google-gtag', { /* module options */ }],
-
-]
-
-// example config
-
-'google-gtag':{
-
-id:  'UA-XXXX-XX', // required
-
-config:{
-
-// this are the config options for `gtag
-
-// check out official docs: https://developers.google.com/analytics/devguides/collection/gtagjs/
-
-anonymize_ip:  true, // anonymize IP
-
-send_page_view:  false, // might be necessary to avoid duplicated page track on page reload
-
-linker:{
-
-domains:['domain.com','domain.org']
-
+ // example config
+ 'google-gtag':{
+   id: 'UA-XXXX-XX', // required
+   config:{
+     // this are the config options for `gtag
+     // check out official docs: https://developers.google.com/analytics/devguides/collection/gtagjs/
+     anonymize_ip: true, // anonymize IP 
+     send_page_view: false, // might be necessary to avoid duplicated page track on page reload
+     linker:{
+       domains:['domain.com','domain.org']
+     }
+   },
+   debug: true, // enable to track in dev mode
+   disableAutoPageTrack: false, // disable if you don't want to track each page route with router.afterEach(...)
+   // optional you can add more configuration like [AdWords](https://developers.google.com/adwords-remarketing-tag/#configuring_the_global_site_tag_for_multiple_accounts)
+   additionalAccounts:[{
+     id: 'AW-XXXX-XX', // required if you are adding additional accounts
+     config:{
+       send_page_view:false // optional configurations
+     }
+   }]
+  }
 }
-
-},
-
-debug:  true, // enable to track in dev mode
-
-disableAutoPageTrack:  false, // disable if you don't want to track each page route with router.afterEach(...)
-
-// optional you can add more configuration like [AdWords](https://developers.google.com/adwords-remarketing-tag/#configuring_the_global_site_tag_for_multiple_accounts)
-
-additionalAccounts:[{
-
-id:  'AW-XXXX-XX', // required if you are adding additional accounts
-
-config:{
-
-send_page_view:false  // optional configurations
-
-}
-
-}]
-
-}
-
-}
-
 ```
-
-  
-
 ## Usage
 If you want to enable Google Tag, you need to call the ``` enableGtagTracking ``` function in your app.
+
 Either by the mounted call of the main component of your app, either by a test condition where you want in your app.
-The call has this syntax: 
+
+The call has this syntax:
+
 ``` this.$enableGtagTracking()```
-
 Example:
-After the user has click the YES button on our cookies disclaimer we can do that:
 
-```
+After the user has click the YES button on our cookies disclaimer we can do that:
+```js
 methods: {
-	cookieClickedAccept() {
-		this.$enableGtagTracking()
-	},
+    cookieClickedAccept() {
+        this.$enableGtagTracking()
+    },
 },
 ```
+After this required step, this module inlcudes Google gtag in your NuxtJs project and enables every page tracking by default. You can use gtag inside of your components/functions/methods like follow:
 
-
-  After this required step, this module inlcudes Google gtag in your NuxtJs project and enables every page tracking by default. You can use gtag inside of your components/functions/methods like follow:
-
-  
+This module inlcudes Google gtag in your NuxtJs project and enables every page tracking by default. You can use gtag inside of your components/functions/methods like follow:
 
 ```
-
-this.$gtag('event', 'your_event', { /* track something awesome */})
-
+  this.$gtag('event', 'your_event', { /* track something awesome */})
 ```
-
 See official docs:
-
-*  [gtagjs](https://developers.google.com/analytics/devguides/collection/gtagjs/)
-
-*  [adwords](https://developers.google.com/adwords-remarketing-tag/#configuring_the_global_site_tag_for_multiple_accounts)
-
-  
+* [gtagjs](https://developers.google.com/analytics/devguides/collection/gtagjs/)
+* [adwords](https://developers.google.com/adwords-remarketing-tag/#configuring_the_global_site_tag_for_multiple_accounts)
 
 ## Check functionalities
 
-  
-
 Install [`Google Tag Assistant`](https://chrome.google.com/webstore/detail/tag-assistant-by-google/kejbdjndbnbjgmefkgdddjlbokphdefk?hl=en) and see if your page is being tracked.
-
-  
 
 ## Development
 
-  
-
 - Clone this repository
-
 - Install dependencies using `yarn install` or `npm install`
-
 - Start development server using `npm run dev`
-
-  
 
 ## License
 
-  
-
 [MIT License](./LICENSE)
-
-  
 
 Copyright (c) Dominic Garms <djgarms@gmail.com>

--- a/README.md
+++ b/README.md
@@ -1,3 +1,19 @@
+# @zenika/nuxtjs-google-gtag
+
+This is a fork of [@nuxtjs/google-gtag](https://github.com/nuxt-community/google-gtag).
+
+With the original lib, the gtag script tag is added through the nuxt config and rendered on the server-side. This is problematic because it means gtag is unconditionally run on the client, even though it adds a cookie on the visitor's computer without their consent, which is illegal in the European Union.
+
+With this fork, the client-side application can control when the gtag script is added to the page, enabling the application developper to correctly implement the law.
+
+To begin tracking, typically after the visitor has given their consent, call `this.$enableGtagTracking()` in any component.
+
+⚠️ No tracking will take place if `this.$enableGtagTracking()` is not called!
+
+The rest of the lib behavior remains intact. `this.$gtag(...)` can even be called before `this.$enableGtagTracking()` without errors, and without loss of events.
+
+The original documentation follows.
+
 # @nuxtjs/google-gtag
 [![npm (scoped with tag)](https://img.shields.io/npm/v/@nuxtjs/google-gtag/latest.svg?style=flat-square)](https://npmjs.com/package/@nuxtjs/google-gtag)
 [![npm](https://img.shields.io/npm/dt/@nuxtjs/google-gtag.svg?style=flat-square)](https://npmjs.com/package/@nuxtjs/google-gtag)
@@ -55,24 +71,6 @@ The module includes Google `googletagmanager.com/gtag/js` into your project and 
 }
 ```
 ## Usage
-If you want to enable Google Tag, you need to call the ` enableGtagTracking ` function in your app.
-
-Either by the mounted call of the main component of your app, either by a test condition where you want in your app.
-
-The call has this syntax:
-
-``` this.$enableGtagTracking()```
-Example:
-
-After the user has click the YES button on our cookies disclaimer we can do that:
-```js
-methods: {
-    cookieClickedAccept() {
-        this.$enableGtagTracking()
-    },
-},
-```
-After this required step, this module inlcudes Google gtag in your NuxtJs project and enables every page tracking by default. You can use gtag inside of your components/functions/methods like follow:
 
 ```
   this.$gtag('event', 'your_event', { /* track something awesome */})

--- a/README.md
+++ b/README.md
@@ -1,83 +1,178 @@
+
 # @nuxtjs/google-gtag
+
 [![npm (scoped with tag)](https://img.shields.io/npm/v/@nuxtjs/google-gtag/latest.svg?style=flat-square)](https://npmjs.com/package/@nuxtjs/google-gtag)
+
 [![npm](https://img.shields.io/npm/dt/@nuxtjs/google-gtag.svg?style=flat-square)](https://npmjs.com/package/@nuxtjs/google-gtag)
+
 [![CircleCI](https://img.shields.io/circleci/project/github/https://github.com/nuxt-community/google-gtag.svg?style=flat-square)](https://circleci.com/gh/https://github.com/nuxt-community/google-gtag)
+
 [![Codecov](https://img.shields.io/codecov/c/github/https://github.com/nuxt-community/google-gtag.svg?style=flat-square)](https://codecov.io/gh/https://github.com/nuxt-community/google-gtag)
+
 [![Dependencies](https://david-dm.org/https://github.com/nuxt-community/google-gtag/status.svg?style=flat-square)](https://david-dm.org/https://github.com/nuxt-community/google-gtag)
+
 [![js-standard-style](https://img.shields.io/badge/code_style-standard-brightgreen.svg?style=flat-square)](http://standardjs.com)
+
+  
 
 > Google official gtagjs for Nuxt.js
 
+  
+
 [📖 **Release Notes**](./CHANGELOG.md)
+
+  
 
 ## Features
 
+  
+
 The module includes Google `googletagmanager.com/gtag/js` into your project and enables it with config you pass in as options.
+
+  
 
 * Check the official reference [gtag](https://developers.google.com/analytics/devguides/collection/gtagjs/)
 
+  
+
 ## Setup
+
 - Add `@nuxtjs/google-gtag` dependency using yarn or npm to your project
+
 - Add `@nuxtjs/google-gtag` to `modules` section of `nuxt.config.js`
 
-```js
-{
-  modules: [
-    // Simple usage
-    '@nuxtjs/google-gtag',
-
-    // With options
-    ['@nuxtjs/google-gtag', { /* module options */ }],    
- ]
   
- // example config
- 'google-gtag':{
-   id: 'UA-XXXX-XX', // required
-   config:{
-     // this are the config options for `gtag
-     // check out official docs: https://developers.google.com/analytics/devguides/collection/gtagjs/
-     anonymize_ip: true, // anonymize IP 
-     send_page_view: false, // might be necessary to avoid duplicated page track on page reload
-     linker:{
-       domains:['domain.com','domain.org']
-     }
-   },
-   debug: true, // enable to track in dev mode
-   disableAutoPageTrack: false, // disable if you don't want to track each page route with router.afterEach(...)
-   // optional you can add more configuration like [AdWords](https://developers.google.com/adwords-remarketing-tag/#configuring_the_global_site_tag_for_multiple_accounts)
-   additionalAccounts:[{
-     id: 'AW-XXXX-XX', // required if you are adding additional accounts
-     config:{
-       send_page_view:false // optional configurations
-     }
-   }]
-  }
+
+```js
+
+{
+
+modules: [
+
+// Simple usage
+
+'@nuxtjs/google-gtag',
+
+  
+
+// With options
+
+['@nuxtjs/google-gtag', { /* module options */ }],
+
+]
+
+// example config
+
+'google-gtag':{
+
+id:  'UA-XXXX-XX', // required
+
+config:{
+
+// this are the config options for `gtag
+
+// check out official docs: https://developers.google.com/analytics/devguides/collection/gtagjs/
+
+anonymize_ip:  true, // anonymize IP
+
+send_page_view:  false, // might be necessary to avoid duplicated page track on page reload
+
+linker:{
+
+domains:['domain.com','domain.org']
+
 }
+
+},
+
+debug:  true, // enable to track in dev mode
+
+disableAutoPageTrack:  false, // disable if you don't want to track each page route with router.afterEach(...)
+
+// optional you can add more configuration like [AdWords](https://developers.google.com/adwords-remarketing-tag/#configuring_the_global_site_tag_for_multiple_accounts)
+
+additionalAccounts:[{
+
+id:  'AW-XXXX-XX', // required if you are adding additional accounts
+
+config:{
+
+send_page_view:false  // optional configurations
+
+}
+
+}]
+
+}
+
+}
+
 ```
+
+  
 
 ## Usage
+If you want to enable Google Tag, you need to call the ``` enableGtagTracking ``` function in your app.
+Either by the mounted call of the main component of your app, either by a test condition where you want in your app.
+The call has this syntax: 
+``` this.$enableGtagTracking()```
 
-This module inlcudes Google gtag in your NuxtJs project and enables every page tracking by default. You can use gtag inside of your components/functions/methods like follow:
+Example:
+After the user has click the YES button on our cookies disclaimer we can do that:
 
 ```
-  this.$gtag('event', 'your_event', { /* track something awesome */})
+methods: {
+	cookieClickedAccept() {
+		this.$enableGtagTracking()
+	},
+},
 ```
+
+
+  After this required step, this module inlcudes Google gtag in your NuxtJs project and enables every page tracking by default. You can use gtag inside of your components/functions/methods like follow:
+
+  
+
+```
+
+this.$gtag('event', 'your_event', { /* track something awesome */})
+
+```
+
 See official docs:
-* [gtagjs](https://developers.google.com/analytics/devguides/collection/gtagjs/)
-* [adwords](https://developers.google.com/adwords-remarketing-tag/#configuring_the_global_site_tag_for_multiple_accounts)
+
+*  [gtagjs](https://developers.google.com/analytics/devguides/collection/gtagjs/)
+
+*  [adwords](https://developers.google.com/adwords-remarketing-tag/#configuring_the_global_site_tag_for_multiple_accounts)
+
+  
 
 ## Check functionalities
 
+  
+
 Install [`Google Tag Assistant`](https://chrome.google.com/webstore/detail/tag-assistant-by-google/kejbdjndbnbjgmefkgdddjlbokphdefk?hl=en) and see if your page is being tracked.
+
+  
 
 ## Development
 
+  
+
 - Clone this repository
+
 - Install dependencies using `yarn install` or `npm install`
+
 - Start development server using `npm run dev`
+
+  
 
 ## License
 
+  
+
 [MIT License](./LICENSE)
+
+  
 
 Copyright (c) Dominic Garms <djgarms@gmail.com>

--- a/lib/module.js
+++ b/lib/module.js
@@ -1,4 +1,4 @@
-const {resolve} = require('path')
+const { resolve } = require('path')
 
 module.exports = function module (moduleOptions) {
   const options = this.options['google-gtag'] || moduleOptions
@@ -15,9 +15,5 @@ module.exports = function module (moduleOptions) {
       options: Object.assign({}, options),
       ssr: false
     })
-
-    if (options.skipAll) {
-      return // skip gtag if not in dev mode
-    }
   }
 }

--- a/lib/module.js
+++ b/lib/module.js
@@ -19,10 +19,5 @@ module.exports = function module (moduleOptions) {
     if (options.skipAll) {
       return // skip gtag if not in dev mode
     }
-
-    this.options.head.script.push({
-      src: `https://www.googletagmanager.com/gtag/js?id=${options.id}`,
-      async: true
-    })
   }
 }

--- a/lib/templates/config.js
+++ b/lib/templates/config.js
@@ -27,7 +27,7 @@ export default function ({app: {router}}, inject) {
     gtag('config', '<%= account.id %>',<%= JSON.stringify(account.config, null,2) %>)
   <% }) %>
 
-  const enableGtagTracking = ()=>{
+  const enableGtagTracking = () => {
     const scriptTag = document.createElement('script')
     scriptTag.setAttribute('src', 'https://www.googletagmanager.com/gtag/js?id=<%= options.id %>`')
     scriptTag.setAttribute('async', 'true')

--- a/lib/templates/config.js
+++ b/lib/templates/config.js
@@ -26,4 +26,13 @@ export default function ({app: {router}}, inject) {
   <% options.additionalAccounts && options.additionalAccounts.forEach((account) => { %>
     gtag('config', '<%= account.id %>',<%= JSON.stringify(account.config, null,2) %>)
   <% }) %>
+
+  const enableGtagTracking = ()=>{
+    const scriptTag = document.createElement('script')
+    scriptTag.setAttribute('src', 'https://www.googletagmanager.com/gtag/js?id=<%= options.id %>`')
+    scriptTag.setAttribute('async', 'true')
+    document.head.appendChild(scriptTag)
+  }
+
+  inject('enableGtagTracking', enableGtagTracking)
 }

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@nuxtjs/google-gtag",
+  "name": "@zenika/nuxtjs-google-gtag",
   "version": "1.0.4",
   "description": "Google GTag for Nuxt.js",
   "license": "MIT",
@@ -9,7 +9,7 @@
     }
   ],
   "main": "lib/module.js",
-  "repository": "https://github.com/https://github.com/nuxt-community/google-gtag",
+  "repository": "https://github.com/Zenika/nuxtjs-google-gtag",
   "publishConfig": {
     "access": "public"
   },

--- a/test/fixture/nuxt.config.js
+++ b/test/fixture/nuxt.config.js
@@ -1,4 +1,4 @@
-const {resolve} = require('path')
+const { resolve } = require('path')
 
 module.exports = {
   rootDir: resolve(__dirname, '../..'),


### PR DESCRIPTION
In order to trigger the insertion of the Google Tag script, we must now call a specific function.
This change is intended to respect the law.
With these modifications, it is now possible to prevent and ask for the user's consent

