### PR TITLE
make script attributes configurable

### DIFF
--- a/lib/module.js
+++ b/lib/module.js
@@ -22,7 +22,8 @@ module.exports = function module (moduleOptions) {
 
     this.options.head.script.push({
       src: `https://www.googletagmanager.com/gtag/js?id=${options.id}`,
-      async: true
+      async: true,
+      ...options.scriptAttrs
     })
   }
 }


### PR DESCRIPTION
Défait l'injection de la balise de script de google analytics si la fonction EnableGtagTracking est appelée, pour revenir à un fonctionnement ou une balise script est directement injecté une fois le paquet chargé.

Modification de l'injection du script afin de pouvoir passer des attributs généraux à celui ci.
 